### PR TITLE
Quick fix import of object type

### DIFF
--- a/src/Sections/Projects/Project.tsx
+++ b/src/Sections/Projects/Project.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import StackSvg from '@Components/StackSvg'
 import JButton from '@Components/JButton'
-import { ProjectObject } from './ProjectList'
+import type { ProjectObject } from './Projects'
 
 export default function Project({ name, description, technologies, repo, live }:ProjectObject) {
   return (

--- a/src/Sections/Projects/Projects.tsx
+++ b/src/Sections/Projects/Projects.tsx
@@ -6,7 +6,7 @@ import type { StackName } from '@Types'
 import type { SectionProps } from '@Hooks/useDivRef'
 import './projects.scss'
 
-interface ProjectObject {
+export interface ProjectObject {
   name: string
   description: string
   technologies: StackName[]


### PR DESCRIPTION
Since ProjectList is now deleted, ProjectObject type is gone
Now said type is imported from Projects parent